### PR TITLE
Expose MIME media-type format in the public API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Added
+
+- Add `NewPacket()`
+- Add `Packet.ParseMediaType()`
+
 ## [0.2.0] - 2020-01-23
 
 ### Changed

--- a/codec/marshaler_test.go
+++ b/codec/marshaler_test.go
@@ -172,7 +172,7 @@ var _ = Describe("type Marshaler", func() {
 
 		It("returns an error if the media-type is not supported", func() {
 			_, err := marshaler.Unmarshal(marshalkit.Packet{
-				MediaType: "text/plain",
+				MediaType: "text/plain; type=MessageA",
 			})
 			Expect(err).To(MatchError(
 				"no codecs support the 'text/plain' media-type",
@@ -214,5 +214,4 @@ var _ = Describe("type Marshaler", func() {
 			Expect(err).Should(HaveOccurred())
 		})
 	})
-
 })

--- a/go.sum
+++ b/go.sum
@@ -3,10 +3,6 @@ github.com/dogmatiq/dogma v0.6.3/go.mod h1:8TdjQ5jjV2DcCPb/jjHPgSrqU66H6092yMEIF
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.3 h1:gyjaxf+svBWX08ZjK86iN9geUJF0H6gp2IRKX6Nf6/I=
-github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
-github.com/golang/protobuf v1.3.4 h1:87PNWwrRvUSnqS4dlcBU/ftvOIBep4sYuBLlh6rX2wk=
-github.com/golang/protobuf v1.3.4/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.3.5 h1:F768QJ1E9tib+q5Sc8MkdJi1RxLTbRcTf8LJV56aRls=
 github.com/golang/protobuf v1.3.5/go.mod h1:6O5/vntMXwX2lRkT1hjjk0nAC1IDOTvTlVgjlRvqsdk=
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=

--- a/packet.go
+++ b/packet.go
@@ -18,12 +18,12 @@ type Packet struct {
 // NewPacket returns a new packet.
 //
 // mt is the MIME media-type describing the content and encoding of the binary
-// data. t is marshaled value's portable type name.
-func NewPacket(mt string, t string, data []byte) Packet {
+// data. n is the marshaled value's portable type name.
+func NewPacket(mt string, n string, data []byte) Packet {
 	return Packet{
 		mime.FormatMediaType(
 			mt,
-			map[string]string{"type": t},
+			map[string]string{"type": n},
 		),
 		data,
 	}
@@ -31,9 +31,6 @@ func NewPacket(mt string, t string, data []byte) Packet {
 
 // ParseMediaType returns the media-type and the portable type name encoded in
 // the packet's MIME media-type.
-//
-// This is equivalent to the string that MarshalType() would return for the
-// unmarshaled value.
 func (p *Packet) ParseMediaType() (string, string, error) {
 	mt, params, err := mime.ParseMediaType(p.MediaType)
 	if err != nil {

--- a/packet.go
+++ b/packet.go
@@ -1,5 +1,10 @@
 package marshalkit
 
+import (
+	"fmt"
+	"mime"
+)
+
 // Packet is a container of marshaled data and its related meta-data.
 type Packet struct {
 	// MediaType is a MIME media-type describing the content and encoding of the
@@ -8,4 +13,39 @@ type Packet struct {
 
 	// Data is the marshaled binary data.
 	Data []byte
+}
+
+// NewPacket returns a new packet.
+//
+// mt is the MIME media-type describing the content and encoding of the binary
+// data. t is marshaled value's portable type name.
+func NewPacket(mt string, t string, data []byte) Packet {
+	return Packet{
+		mime.FormatMediaType(
+			mt,
+			map[string]string{"type": t},
+		),
+		data,
+	}
+}
+
+// ParseMediaType returns the media-type and the portable type name encoded in
+// the packet's MIME media-type.
+//
+// This is equivalent to the string that MarshalType() would return for the
+// unmarshaled value.
+func (p *Packet) ParseMediaType() (string, string, error) {
+	mt, params, err := mime.ParseMediaType(p.MediaType)
+	if err != nil {
+		return "", "", err
+	}
+
+	if n, ok := params["type"]; ok {
+		return mt, n, nil
+	}
+
+	return "", "", fmt.Errorf(
+		"the media-type '%s' does not specify a 'type' parameter",
+		p.MediaType,
+	)
 }

--- a/packet_test.go
+++ b/packet_test.go
@@ -1,0 +1,59 @@
+package marshalkit_test
+
+import (
+	. "github.com/dogmatiq/marshalkit"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Packet", func() {
+	Describe("func NewPacket()", func() {
+		It("encodes the portable type name in the media-type", func() {
+			p := NewPacket(
+				"text/plain",
+				"SomeType",
+				[]byte("data"),
+			)
+
+			Expect(p).To(Equal(
+				Packet{
+					MediaType: "text/plain; type=SomeType",
+					Data:      []byte("data"),
+				},
+			))
+		})
+	})
+
+	Describe("func ParseMediaType()", func() {
+		It("returns the mime-type and portable type name", func() {
+			p := NewPacket(
+				"text/plain",
+				"SomeType",
+				[]byte("data"),
+			)
+
+			mt, n, err := p.ParseMediaType()
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(mt).To(Equal("text/plain"))
+			Expect(n).To(Equal("SomeType"))
+		})
+
+		It("returns an error if the media-type has no type parameter", func() {
+			p := Packet{
+				MediaType: "text/plain",
+			}
+
+			_, _, err := p.ParseMediaType()
+			Expect(err).To(MatchError("the media-type 'text/plain' does not specify a 'type' parameter"))
+		})
+
+		It("returns an error if the media-type is malformed", func() {
+			p := Packet{
+				MediaType: "<malformed>",
+			}
+
+			_, _, err := p.ParseMediaType()
+			Expect(err).Should(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
This PR adds the `NewPacket()` and `Packet.ParseMediaType()` functions, which serve to make the format of the MIME media-type used to identify messages available to the outside world.

The media-type already encoded both the "base" media-type, such as `text/plain` as well as the "portable type name", a `marshalkit` concept for uniquely identifying Go types without referring to their package names (which may change over time). 