### PR TITLE
Add .MediaTypesFor() method on Marshaler.

### DIFF
--- a/codec/marshaler.go
+++ b/codec/marshaler.go
@@ -169,7 +169,7 @@ func (m *Marshaler) Unmarshal(p marshalkit.Packet) (interface{}, error) {
 }
 
 // MediaTypesFor returns the the media-types that the marshaler can use to
-// represent the given type, in order of preference. 
+// represent the given type, in order of preference.
 //
 // It returns an empty slice if the type is not supported.
 func (m *Marshaler) MediaTypesFor(rt reflect.Type) []string {

--- a/codec/marshaler.go
+++ b/codec/marshaler.go
@@ -168,8 +168,10 @@ func (m *Marshaler) Unmarshal(p marshalkit.Packet) (interface{}, error) {
 	return v.Interface(), nil
 }
 
-// MediaTypesFor returns the list of supported media types for unmarshaling
-// the given type.
+// MediaTypesFor returns the the media-types that the marshaler can use to
+// represent the given type, in order of preference. 
+//
+// It returns an empty slice if the type is not supported.
 func (m *Marshaler) MediaTypesFor(rt reflect.Type) []string {
 	return m.mtypes[rt]
 }

--- a/codec/marshaler.go
+++ b/codec/marshaler.go
@@ -168,7 +168,7 @@ func (m *Marshaler) Unmarshal(p marshalkit.Packet) (interface{}, error) {
 	return v.Interface(), nil
 }
 
-// MediaTypesFor returns the the media-types that the marshaler can use to
+// MediaTypesFor returns the media-types that the marshaler can use to
 // represent the given type, in order of preference.
 //
 // It returns an empty slice if the type is not supported.

--- a/codec/marshaler_test.go
+++ b/codec/marshaler_test.go
@@ -223,7 +223,7 @@ var _ = Describe("type Marshaler", func() {
 				"application/vnd.google.protobuf; type=dogmatiq.marshalkit.fixtures.ProtoMessage",
 				"application/vnd.google.protobuf+json; type=dogmatiq.marshalkit.fixtures.ProtoMessage",
 				"application/json; type=ProtoMessage",
-			})
+			}))
 		})
 
 		It("returns an empty slice when given an unsupported message type", func() {

--- a/codec/marshaler_test.go
+++ b/codec/marshaler_test.go
@@ -215,4 +215,20 @@ var _ = Describe("type Marshaler", func() {
 			Expect(err).Should(HaveOccurred())
 		})
 	})
+
+	Describe("func MediaTypesFor()", func() {
+		It("returns media types for the existing message type in order of codec priority", func() {
+			mt := marshaler.MediaTypesFor(reflect.TypeOf(&ProtoMessage{}))
+			Expect(mt).To(HaveLen(3))
+
+			Expect(mt[0]).To(Equal("application/vnd.google.protobuf; type=dogmatiq.marshalkit.fixtures.ProtoMessage"))
+			Expect(mt[1]).To(Equal("application/vnd.google.protobuf+json; type=dogmatiq.marshalkit.fixtures.ProtoMessage"))
+			Expect(mt[2]).To(Equal("application/json; type=ProtoMessage"))
+		})
+
+		It("returns an empty slice for a non-existing message type", func() {
+			mt := marshaler.MediaTypesFor(reflect.TypeOf(&MessageC{}))
+			Expect(mt).To(HaveLen(0))
+		})
+	})
 })

--- a/codec/marshaler_test.go
+++ b/codec/marshaler_test.go
@@ -217,18 +217,18 @@ var _ = Describe("type Marshaler", func() {
 	})
 
 	Describe("func MediaTypesFor()", func() {
-		It("returns media types for the existing message type in order of codec priority", func() {
+		It("returns media types in order of codec priority", func() {
 			mt := marshaler.MediaTypesFor(reflect.TypeOf(&ProtoMessage{}))
-			Expect(mt).To(HaveLen(3))
-
-			Expect(mt[0]).To(Equal("application/vnd.google.protobuf; type=dogmatiq.marshalkit.fixtures.ProtoMessage"))
-			Expect(mt[1]).To(Equal("application/vnd.google.protobuf+json; type=dogmatiq.marshalkit.fixtures.ProtoMessage"))
-			Expect(mt[2]).To(Equal("application/json; type=ProtoMessage"))
+			Expect(mt).To(Equal([]string{
+				"application/vnd.google.protobuf; type=dogmatiq.marshalkit.fixtures.ProtoMessage",
+				"application/vnd.google.protobuf+json; type=dogmatiq.marshalkit.fixtures.ProtoMessage",
+				"application/json; type=ProtoMessage",
+			})
 		})
 
-		It("returns an empty slice for a non-existing message type", func() {
+		It("returns an empty slice when given an unsupported message type", func() {
 			mt := marshaler.MediaTypesFor(reflect.TypeOf(&MessageC{}))
-			Expect(mt).To(HaveLen(0))
+			Expect(mt).To(BeEmpty())
 		})
 	})
 })

--- a/value.go
+++ b/value.go
@@ -1,5 +1,9 @@
 package marshalkit
 
+import (
+	"reflect"
+)
+
 // A ValueMarshaler marshals and unmarshals arbitrary Go values.
 type ValueMarshaler interface {
 	// Marshal returns a binary representation of v.
@@ -7,6 +11,10 @@ type ValueMarshaler interface {
 
 	// Unmarshal produces a value from its binary representation.
 	Unmarshal(p Packet) (interface{}, error)
+
+	// MediaTypesFor returns the list of supported media types for unmarshaling
+	// the given type.
+	MediaTypesFor(reflect.Type) []string
 }
 
 // MustMarshal returns a binary representation of v.

--- a/value.go
+++ b/value.go
@@ -12,8 +12,10 @@ type ValueMarshaler interface {
 	// Unmarshal produces a value from its binary representation.
 	Unmarshal(p Packet) (interface{}, error)
 
-	// MediaTypesFor returns the list of supported media types for unmarshaling
-	// the given type.
+	// MediaTypesFor returns the the media-types that the marshaler can use to
+	// represent the given type, in order of preference. 
+	//
+	// It returns an empty slice if the type is not supported.
 	MediaTypesFor(reflect.Type) []string
 }
 

--- a/value.go
+++ b/value.go
@@ -13,7 +13,7 @@ type ValueMarshaler interface {
 	Unmarshal(p Packet) (interface{}, error)
 
 	// MediaTypesFor returns the the media-types that the marshaler can use to
-	// represent the given type, in order of preference. 
+	// represent the given type, in order of preference.
 	//
 	// It returns an empty slice if the type is not supported.
 	MediaTypesFor(reflect.Type) []string

--- a/value.go
+++ b/value.go
@@ -12,7 +12,7 @@ type ValueMarshaler interface {
 	// Unmarshal produces a value from its binary representation.
 	Unmarshal(p Packet) (interface{}, error)
 
-	// MediaTypesFor returns the the media-types that the marshaler can use to
+	// MediaTypesFor returns the media-types that the marshaler can use to
 	// represent the given type, in order of preference.
 	//
 	// It returns an empty slice if the type is not supported.


### PR DESCRIPTION
#### What change does this introduce?

This PR adds `MediaTypesFor()` method on the `Marshaler` interface and implements this method in the existing implementation.

#### What issues does this relate to?

Fixes https://github.com/dogmatiq/marshalkit/issues/15.

#### Why make this change?

This change is required to supply all media types supported by the `Marshaler` implementation to marshal the specific message type.

#### Is there anything you are unsure about?

I am not sure about the implementation of this method. it seems too simple. I am also not sure about the scope of the unit tests written.