### PR TITLE
Organize media type funcs. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 - Added `String()` method to `PanicSentinel`
 
+### Changed
+
+- **[BC]** Rename `codec.Codec.MediaType()` to `BasicMediaType()`
+
 ### Removed
 
 - **[BC]** Remove `MarshalMessage()`, `UnmarshalMessage()`, `MustMarshalMessage()`, and `MustUnmarshalMessage()`

--- a/codec/codec.go
+++ b/codec/codec.go
@@ -7,9 +7,9 @@ type Codec interface {
 	// Query returns the capabilities of the codec for the given types.
 	Query(types []reflect.Type) Capabilities
 
-	// MediaType returns the media-type used to identify values encoded by this
-	// codec.
-	MediaType() string
+	// BasicMediaType returns the type and subtype portion of the media-type
+	// used to identify data encoded by this codec.
+	BasicMediaType() string
 
 	// Marshal returns the binary representation of v.
 	Marshal(v interface{}) ([]byte, error)

--- a/codec/json/codec.go
+++ b/codec/json/codec.go
@@ -26,9 +26,9 @@ func (*Codec) Query(types []reflect.Type) codec.Capabilities {
 	return caps
 }
 
-// MediaType returns the media-type used to identify data encoded by this
-// codec.
-func (*Codec) MediaType() string {
+// BasicMediaType returns the type and subtype portion of the media-type used to
+// identify data encoded by this codec.
+func (*Codec) BasicMediaType() string {
 	return "application/json"
 }
 

--- a/codec/json/codec_test.go
+++ b/codec/json/codec_test.go
@@ -51,9 +51,9 @@ var _ = Describe("type Codec", func() {
 		})
 	})
 
-	Describe("func MediaType()", func() {
-		It("returns the expected media-type", func() {
-			Expect(codec.MediaType()).To(Equal("application/json"))
+	Describe("func BasicMediaType()", func() {
+		It("returns the expected basic media-type", func() {
+			Expect(codec.BasicMediaType()).To(Equal("application/json"))
 		})
 	})
 

--- a/codec/marshaler.go
+++ b/codec/marshaler.go
@@ -64,14 +64,14 @@ func NewMarshaler(
 				delete(unsupported, rt)
 			}
 
-			if _, ok := m.decoders[c.MediaType()]; ok {
+			if _, ok := m.decoders[c.BasicMediaType()]; ok {
 				return nil, fmt.Errorf(
 					"multiple codecs use the '%s' media-type",
-					c.MediaType(),
+					c.BasicMediaType(),
 				)
 			}
 
-			m.decoders[c.MediaType()] = c
+			m.decoders[c.BasicMediaType()] = c
 		}
 	}
 
@@ -120,7 +120,7 @@ func (m *Marshaler) Marshal(v interface{}) (marshalkit.Packet, error) {
 		}
 
 		return marshalkit.NewPacket(
-			c.MediaType(),
+			c.BasicMediaType(),
 			m.names[rt],
 			data,
 		), nil

--- a/codec/protobuf/json.go
+++ b/codec/protobuf/json.go
@@ -32,9 +32,9 @@ type JSONCodec struct {
 	Unmarshaler *jsonpb.Unmarshaler
 }
 
-// MediaType returns the media-type used to identify values encoded by this
-// codec.
-func (c *JSONCodec) MediaType() string {
+// BasicMediaType returns the type and subtype portion of the media-type used to
+// identify data encoded by this codec.
+func (c *JSONCodec) BasicMediaType() string {
 	return "application/vnd.google.protobuf+json"
 }
 

--- a/codec/protobuf/json_test.go
+++ b/codec/protobuf/json_test.go
@@ -16,9 +16,9 @@ var _ = Describe("type JSONCodec", func() {
 		codec = &JSONCodec{}
 	})
 
-	Describe("func MediaType()", func() {
-		It("returns the expected media-type", func() {
-			Expect(codec.MediaType()).To(Equal("application/vnd.google.protobuf+json"))
+	Describe("func BasicMediaType()", func() {
+		It("returns the expected basic media-type", func() {
+			Expect(codec.BasicMediaType()).To(Equal("application/vnd.google.protobuf+json"))
 		})
 	})
 

--- a/codec/protobuf/native.go
+++ b/codec/protobuf/native.go
@@ -10,9 +10,9 @@ type NativeCodec struct {
 	commonCodec
 }
 
-// MediaType returns the media-type used to identify values encoded by this
-// codec.
-func (c *NativeCodec) MediaType() string {
+// BasicMediaType returns the type and subtype portion of the media-type used to
+// identify data encoded by this codec.
+func (c *NativeCodec) BasicMediaType() string {
 	return "application/vnd.google.protobuf"
 }
 

--- a/codec/protobuf/native_test.go
+++ b/codec/protobuf/native_test.go
@@ -17,9 +17,9 @@ var _ = Describe("type NativeCodec", func() {
 		codec = &NativeCodec{}
 	})
 
-	Describe("func MediaType()", func() {
-		It("returns the expected media-type", func() {
-			Expect(codec.MediaType()).To(Equal("application/vnd.google.protobuf"))
+	Describe("func BasicMediaType()", func() {
+		It("returns the expected basic media-type", func() {
+			Expect(codec.BasicMediaType()).To(Equal("application/vnd.google.protobuf"))
 		})
 	})
 

--- a/codec/protobuf/text.go
+++ b/codec/protobuf/text.go
@@ -23,9 +23,9 @@ type TextCodec struct {
 	Marshaler *proto.TextMarshaler
 }
 
-// MediaType returns the media-type used to identify values encoded by this
-// codec.
-func (c *TextCodec) MediaType() string {
+// BasicMediaType returns the type and subtype portion of the media-type used to
+// identify data encoded by this codec.
+func (c *TextCodec) BasicMediaType() string {
 	return "text/vnd.google.protobuf"
 }
 

--- a/codec/protobuf/text_test.go
+++ b/codec/protobuf/text_test.go
@@ -16,9 +16,9 @@ var _ = Describe("type TextCodec", func() {
 		codec = &TextCodec{}
 	})
 
-	Describe("func MediaType()", func() {
-		It("returns the expected media-type", func() {
-			Expect(codec.MediaType()).To(Equal("text/vnd.google.protobuf"))
+	Describe("func BasicMediaType()", func() {
+		It("returns the expected basic media-type", func() {
+			Expect(codec.BasicMediaType()).To(Equal("text/vnd.google.protobuf"))
 		})
 	})
 

--- a/internal/mimex/mime.go
+++ b/internal/mimex/mime.go
@@ -1,19 +1,33 @@
 package mimex
 
+import (
+	"fmt"
+	"mime"
+)
+
+// FormatMediaType returns the media-type as the base media type and the
+// message's portable name as the 'type' parameter.
+func FormatMediaType(base string, portableName string) string {
+	return mime.FormatMediaType(
+		base,
+		map[string]string{"type": portableName},
+	)
+}
+
 // ParseMediaType returns the media-type and the portable type name encoded in
 // the packet's MIME media-type.
-// func ParseMediaType(mt string) (string, string, error) {
-// 	mt, params, err := mime.ParseMediaType(p.MediaType)
-// 	if err != nil {
-// 		return "", "", err
-// 	}
+func ParseMediaType(mediatype string) (string, string, error) {
+	mt, params, err := mime.ParseMediaType(mediatype)
+	if err != nil {
+		return "", "", err
+	}
 
-// 	if n, ok := params["type"]; ok {
-// 		return mt, n, nil
-// 	}
+	if n, ok := params["type"]; ok {
+		return mt, n, nil
+	}
 
-// 	return "", "", fmt.Errorf(
-// 		"the media-type '%s' does not specify a 'type' parameter",
-// 		p.MediaType,
-// 	)
-// }
+	return "", "", fmt.Errorf(
+		"the media-type '%s' does not specify a 'type' parameter",
+		mediatype,
+	)
+}

--- a/internal/mimex/mime.go
+++ b/internal/mimex/mime.go
@@ -1,0 +1,19 @@
+package mimex
+
+// ParseMediaType returns the media-type and the portable type name encoded in
+// the packet's MIME media-type.
+// func ParseMediaType(mt string) (string, string, error) {
+// 	mt, params, err := mime.ParseMediaType(p.MediaType)
+// 	if err != nil {
+// 		return "", "", err
+// 	}
+
+// 	if n, ok := params["type"]; ok {
+// 		return mt, n, nil
+// 	}
+
+// 	return "", "", fmt.Errorf(
+// 		"the media-type '%s' does not specify a 'type' parameter",
+// 		p.MediaType,
+// 	)
+// }

--- a/packet.go
+++ b/packet.go
@@ -1,8 +1,7 @@
 package marshalkit
 
 import (
-	"fmt"
-	"mime"
+	"github.com/dogmatiq/marshalkit/internal/mimex"
 )
 
 // Packet is a container of marshaled data and its related meta-data.
@@ -21,10 +20,7 @@ type Packet struct {
 // data. n is the marshaled value's portable type name.
 func NewPacket(mt string, n string, data []byte) Packet {
 	return Packet{
-		mime.FormatMediaType(
-			mt,
-			map[string]string{"type": n},
-		),
+		mimex.FormatMediaType(mt, n),
 		data,
 	}
 }
@@ -32,17 +28,5 @@ func NewPacket(mt string, n string, data []byte) Packet {
 // ParseMediaType returns the media-type and the portable type name encoded in
 // the packet's MIME media-type.
 func (p *Packet) ParseMediaType() (string, string, error) {
-	mt, params, err := mime.ParseMediaType(p.MediaType)
-	if err != nil {
-		return "", "", err
-	}
-
-	if n, ok := params["type"]; ok {
-		return mt, n, nil
-	}
-
-	return "", "", fmt.Errorf(
-		"the media-type '%s' does not specify a 'type' parameter",
-		p.MediaType,
-	)
+	return mimex.ParseMediaType(p.MediaType)
 }


### PR DESCRIPTION
#### What change does this introduce?

This change renames `Codec.MediaTypes()` to `Codec.BasicMediaType()` method and groups all MIME utility functions into the internal `memex` package so that the functions can be reused throughout the repository.

#### What issues does this relate to?

Partially addresses https://github.com/dogmatiq/marshalkit/issues/15

#### Why make this change?

This change is all about MIME-specific methods and utility functions:

- Renaming `Codec.MediaTypes()` to `Codec.BasicMediaType()` to show the exact return type
- Grouping all MIME utility functions into the internal `memex` package to share the utility functions throughout the repository.

#### Is there anything you are unsure about?

Doc comment wording for the the renamed/introduced functions/methods might need reviewing.