### PR TITLE
Optimize type encapsulation in Marshaler.

### DIFF
--- a/codec/marshaler.go
+++ b/codec/marshaler.go
@@ -5,7 +5,6 @@ import (
 	"reflect"
 
 	"github.com/dogmatiq/marshalkit/internal/mimex"
-
 	"github.com/dogmatiq/marshalkit"
 )
 

--- a/codec/marshaler.go
+++ b/codec/marshaler.go
@@ -12,13 +12,13 @@ import (
 // Marshaler uses a set of priority-ordered codecs to marshal and unmarshal
 // types and values.
 type Marshaler struct {
-	byType map[reflect.Type]struct {
+	types map[reflect.Type]struct {
 		encoder      Codec
 		portableName string
 		mediaTypes   []string
 	}
-	byBasicMediaType map[string]Codec
-	byName           map[string]reflect.Type
+	decoderByBasicMediaType map[string]Codec
+	typeByPortableName           map[string]reflect.Type
 }
 
 // NewMarshaler returns a new marshaler that uses the given set of codecs to


### PR DESCRIPTION

#### What change does this introduce?

This change optimizes type encapsulation in and refactors type handling in `codec.Marshaler`.

#### What issues does this relate to?

Partially addresses https://github.com/dogmatiq/marshalkit/issues/50

#### Why make this change?

This change is required to optimize and group the types inside the  `codec.Marshaler` that lays basis for future `Marshaler`'s methods.

#### Is there anything you are unsure about?

No.
