### PR TITLE
Add method for marshaling a value to a specific mime-type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ### Added
 
+- **[BC]** Added `MarshalAs()` method to `ValueMarshaler`
 - Added `String()` method to `PanicSentinel`
 
 ### Changed

--- a/codec/marshaler_test.go
+++ b/codec/marshaler_test.go
@@ -151,7 +151,7 @@ var _ = Describe("type Marshaler", func() {
 	})
 
 	Describe("func MarshalAs()", func() {
-		It("marshals using the given suitable codec", func() {
+		It("marshals using the codec associated with the given media type", func() {
 			expected := []byte("{\"Value\":null}")
 			p, err := marshaler.MarshalAs(
 				MessageA{},
@@ -201,7 +201,7 @@ var _ = Describe("type Marshaler", func() {
 			))
 		})
 
-		It("returns an error if the portable name does not match", func() {
+		It("returns an error if the portable name in the media-type does not match the value's type", func() {
 			_, err := marshaler.MarshalAs(
 				MessageA{},
 				"application/json; type=MessageC",

--- a/codec/marshaler_test.go
+++ b/codec/marshaler_test.go
@@ -152,16 +152,14 @@ var _ = Describe("type Marshaler", func() {
 
 	Describe("func MarshalAs()", func() {
 		It("marshals using the codec associated with the given media type", func() {
-			expected := []byte("{\"Value\":null}")
 			p, err := marshaler.MarshalAs(
 				MessageA{},
 				"application/json; type=MessageA",
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(p.MediaType).To(Equal("application/json; type=MessageA"))
-			Expect(p.Data).To(Equal(expected))
+			Expect(p.Data).To(Equal([]byte(`{"Value":null}`)))
 
-			expected = []byte{10, 7, 60, 118, 97, 108, 117, 101, 62}
 			p, err = marshaler.MarshalAs(
 				&ProtoMessage{
 					Value: "<value>",
@@ -170,7 +168,7 @@ var _ = Describe("type Marshaler", func() {
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(p.MediaType).To(Equal("application/vnd.google.protobuf; type=dogmatiq.marshalkit.fixtures.ProtoMessage"))
-			Expect(p.Data).To(Equal(expected))
+			Expect(p.Data).To(Equal([]byte{10, 7, 60, 118, 97, 108, 117, 101, 62}))
 		})
 
 		It("returns an error if the media-type is malformed", func() {

--- a/value.go
+++ b/value.go
@@ -9,6 +9,12 @@ type ValueMarshaler interface {
 	// Marshal returns a binary representation of v.
 	Marshal(v interface{}) (Packet, error)
 
+	// MarshalAs returns a binary representation of v in the format described by
+	// a specific media-type.
+	//
+	// If the given media-type is not supported, an error is returned.
+	MarshalAs(v interface{}, mt string) (Packet, error)
+
 	// Unmarshal produces a value from its binary representation.
 	Unmarshal(p Packet) (interface{}, error)
 


### PR DESCRIPTION

#### What change does this introduce?

This PR adds `Marshal.MarshalAs()` method to the interface and its implementation.

#### What issues does this relate to?

Fixes https://github.com/dogmatiq/marshalkit/issues/50.

#### Why make this change?

This change is required to facilitate marshaling the message using any supported codec inside the marshaler.

#### Is there anything you are unsure about?

Unit tests are mostly copied and modified from the `.Marshal()` method, I wonder how well-suited they are.
