### PR TITLE
Support non-default portable name in `MarshalAs()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [Unreleased]
+
+### Fixed
+
+- Fix `MarshalAs()` issue that prevented encoding when the media-type's portable name differed to that of the default codec
+
 ## [0.5.0] - 2021-01-20
 
 ### Added

--- a/codec/marshaler_test.go
+++ b/codec/marshaler_test.go
@@ -124,13 +124,23 @@ var _ = Describe("type Marshaler", func() {
 
 	Describe("func Marshal()", func() {
 		It("marshals using the first suitable codec", func() {
-			p, err := marshaler.Marshal(MessageA{})
+			p, err := marshaler.Marshal(
+				MessageA{
+					Value: "<value>",
+				},
+			)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(p.MediaType).To(Equal("application/json; type=MessageA"))
+			Expect(p.Data).To(Equal([]byte(`{"Value":"\u003cvalue\u003e"}`)))
 
-			p, err = marshaler.Marshal(&ProtoMessage{})
+			p, err = marshaler.Marshal(
+				&ProtoMessage{
+					Value: "<value>",
+				},
+			)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(p.MediaType).To(Equal("application/vnd.google.protobuf; type=dogmatiq.marshalkit.fixtures.ProtoMessage"))
+			Expect(p.Data).To(Equal([]byte{10, 7, 60, 118, 97, 108, 117, 101, 62}))
 		})
 
 		It("returns an error if the codec fails", func() {
@@ -153,12 +163,14 @@ var _ = Describe("type Marshaler", func() {
 	Describe("func MarshalAs()", func() {
 		It("marshals using the codec associated with the given media type", func() {
 			p, err := marshaler.MarshalAs(
-				MessageA{},
+				MessageA{
+					Value: "<value>",
+				},
 				"application/json; type=MessageA",
 			)
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(p.MediaType).To(Equal("application/json; type=MessageA"))
-			Expect(p.Data).To(Equal([]byte(`{"Value":null}`)))
+			Expect(p.Data).To(Equal([]byte(`{"Value":"\u003cvalue\u003e"}`)))
 
 			p, err = marshaler.MarshalAs(
 				&ProtoMessage{
@@ -169,6 +181,16 @@ var _ = Describe("type Marshaler", func() {
 			Expect(err).ShouldNot(HaveOccurred())
 			Expect(p.MediaType).To(Equal("application/vnd.google.protobuf; type=dogmatiq.marshalkit.fixtures.ProtoMessage"))
 			Expect(p.Data).To(Equal([]byte{10, 7, 60, 118, 97, 108, 117, 101, 62}))
+
+			p, err = marshaler.MarshalAs(
+				&ProtoMessage{
+					Value: "<value>",
+				},
+				"application/json; type=ProtoMessage",
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(p.MediaType).To(Equal("application/json; type=ProtoMessage"))
+			Expect(p.Data).To(Equal([]byte(`{"value":"\u003cvalue\u003e"}`)))
 		})
 
 		It("returns an error if the media-type is malformed", func() {


### PR DESCRIPTION

<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR fixes a bug whereby `MarshalAs()` did not work if the supplied media-type used a portable name different to the portable named used by the default codec for that type. That is, the codec that would be used when calling `Marshal()`.

I also updated the field names used to represent the default codec and portable name for each type to make it clearer that they were defaults.

#### Why make this change?

Bug fix, this function should support all of the media-types returned by `MediaTypesFor()`.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
