### PR TITLE
Pass multiple media-types to `MarshalAs()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Changed
+
+- **[BC]** `ValueMarshaler.MarshalAs()` now accepts multiple media-types in order of preference
+- **[BC]** `ValueMarshaler.MarshalAs()` now returns a boolean to indicate unsupported media-types
+
 ### Fixed
 
 - Fix `MarshalAs()` issue that prevented encoding when the media-type's portable name differed to that of the default codec

--- a/value.go
+++ b/value.go
@@ -9,11 +9,12 @@ type ValueMarshaler interface {
 	// Marshal returns a binary representation of v.
 	Marshal(v interface{}) (Packet, error)
 
-	// MarshalAs returns a binary representation of v in the format described by
-	// a specific media-type.
+	// MarshalAs returns a binary representation of v encoded using a format
+	// associated with one of the supplied media-types.
 	//
-	// If the given media-type is not supported, an error is returned.
-	MarshalAs(v interface{}, mt string) (Packet, error)
+	// mediaTypes is a list of acceptible media-types, in order of preference.
+	// If none of the media-types are supported, ok is false.
+	MarshalAs(v interface{}, mediaTypes []string) (p Packet, ok bool, err error)
 
 	// Unmarshal produces a value from its binary representation.
 	Unmarshal(p Packet) (interface{}, error)


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR changes the `ValueMarshaler.MarshalAs()` method to accept a slice of media-types in order of preference, rather than a single media-type.

#### Why make this change?

To allow for basic "content negotiation" as required by the `eventstreamspec.StreamAPI` service, etc.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
