### PR TITLE
Add CBOR codec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ The format is based on [Keep a Changelog], and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Add `codec/cbor` package
+
 ### Changed
 
 - **[BC]** `ValueMarshaler.MarshalAs()` now accepts multiple media-types in order of preference

--- a/codec/cbor/codec.go
+++ b/codec/cbor/codec.go
@@ -1,0 +1,57 @@
+package cbor
+
+import (
+	"reflect"
+
+	"github.com/dogmatiq/marshalkit/codec"
+	"github.com/fxamacker/cbor/v2"
+)
+
+// Codec is an implementation of marshalkit.Codec that uses CBOR encoding.
+type Codec struct{}
+
+// Query returns the capabilities of the codec for the given types.
+func (*Codec) Query(types []reflect.Type) codec.Capabilities {
+	caps := codec.Capabilities{
+		Types: map[reflect.Type]string{},
+	}
+
+	for _, rt := range types {
+		if n, ok := portableName(rt); ok {
+			caps.Types[rt] = n
+		}
+	}
+
+	return caps
+}
+
+// BasicMediaType returns the type and subtype portion of the media-type used to
+// identify data encoded by this codec.
+func (*Codec) BasicMediaType() string {
+	return "application/cbor"
+}
+
+// Marshal returns the binary representation of v.
+func (*Codec) Marshal(v interface{}) ([]byte, error) {
+	return cbor.Marshal(v)
+}
+
+// Unmarshal decodes a binary representation into v.
+func (*Codec) Unmarshal(data []byte, v interface{}) error {
+	return cbor.Unmarshal(data, v)
+}
+
+// portableName returns the portable name to use for the given type.
+func portableName(rt reflect.Type) (string, bool) {
+	n := rt.Name()
+	if n != "" {
+		return n, true
+	}
+
+	for rt.Kind() == reflect.Ptr {
+		rt = rt.Elem()
+	}
+
+	n = rt.Name()
+	return n, n != ""
+}

--- a/codec/cbor/codec_test.go
+++ b/codec/cbor/codec_test.go
@@ -1,0 +1,86 @@
+package cbor_test
+
+import (
+	"reflect"
+
+	. "github.com/dogmatiq/dogma/fixtures"
+	. "github.com/dogmatiq/marshalkit/codec/cbor"
+	. "github.com/dogmatiq/marshalkit/codec/internal/fixtures"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("type Codec", func() {
+	var codec *Codec
+
+	BeforeEach(func() {
+		codec = &Codec{}
+	})
+
+	Describe("func Query()", func() {
+		It("uses the unqualified type-name as the portable type", func() {
+			rt := reflect.TypeOf(MessageA{})
+
+			caps := codec.Query(
+				[]reflect.Type{rt},
+			)
+
+			Expect(caps.Types[rt]).To(Equal("MessageA"))
+		})
+
+		It("uses the user-defined type name", func() {
+			type LocalMessage MessageA
+			rt := reflect.TypeOf(LocalMessage{})
+
+			caps := codec.Query(
+				[]reflect.Type{rt},
+			)
+
+			Expect(caps.Types[rt]).To(Equal("LocalMessage"))
+		})
+
+		It("uses the element name for pointer types", func() {
+			var m **MessageA
+			rt := reflect.TypeOf(m)
+
+			caps := codec.Query(
+				[]reflect.Type{rt},
+			)
+
+			Expect(caps.Types[rt]).To(Equal("MessageA"))
+		})
+	})
+
+	Describe("func BasicMediaType()", func() {
+		It("returns the expected basic media-type", func() {
+			Expect(codec.BasicMediaType()).To(Equal("application/cbor"))
+		})
+	})
+
+	Describe("func Marshal()", func() {
+		It("marshals the value", func() {
+			data, err := codec.Marshal(
+				&ProtoMessage{
+					Value: "<value>",
+				},
+			)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(data).To(Equal([]byte("\xa1evalueg<value>")))
+		})
+	})
+
+	Describe("func Unmarshal()", func() {
+		It("unmarshals the data", func() {
+			data := []byte("\xa1evalueg<value>")
+
+			m := &ProtoMessage{}
+			err := codec.Unmarshal(data, m)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(m).To(Equal(
+				&ProtoMessage{
+					Value: "<value>",
+				},
+			))
+		})
+	})
+})

--- a/codec/cbor/doc.go
+++ b/codec/cbor/doc.go
@@ -1,0 +1,2 @@
+// Package cbor contains a codec implementation that marshals in CBOR format.
+package cbor

--- a/codec/cbor/ginkgo_test.go
+++ b/codec/cbor/ginkgo_test.go
@@ -1,0 +1,15 @@
+package cbor_test
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/onsi/ginkgo"
+	"github.com/onsi/gomega"
+)
+
+func TestSuite(t *testing.T) {
+	type tag struct{}
+	gomega.RegisterFailHandler(ginkgo.Fail)
+	ginkgo.RunSpecs(t, reflect.TypeOf(tag{}).PkgPath())
+}

--- a/codec/json/doc.go
+++ b/codec/json/doc.go
@@ -1,3 +1,2 @@
-// Package json contains codec implementations that use Go's standard JSON
-// marshaling.
+// Package json contains a codec that use Go's standard JSON marshaling.
 package json

--- a/codec/json/doc.go
+++ b/codec/json/doc.go
@@ -1,2 +1,2 @@
-// Package json contains a codec that use Go's standard JSON marshaling.
+// Package json contains a codec that uses Go's standard JSON marshaling.
 package json

--- a/fixtures/marshaler.go
+++ b/fixtures/marshaler.go
@@ -6,6 +6,7 @@ import (
 	"github.com/dogmatiq/dogma/fixtures"
 	"github.com/dogmatiq/marshalkit"
 	"github.com/dogmatiq/marshalkit/codec"
+	"github.com/dogmatiq/marshalkit/codec/cbor"
 	"github.com/dogmatiq/marshalkit/codec/json"
 )
 
@@ -47,6 +48,7 @@ func init() {
 		},
 		[]codec.Codec{
 			&json.Codec{},
+			&cbor.Codec{},
 		},
 	)
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/dogmatiq/configkit v0.10.0
 	github.com/dogmatiq/dogma v0.10.0
 	github.com/dogmatiq/interopspec v0.5.0
+	github.com/fxamacker/cbor/v2 v2.2.0
 	github.com/golang/protobuf v1.4.3
 	github.com/jmalloc/gomegax v0.0.0-20200507221434-64fca4c0e03a
 	github.com/onsi/ginkgo v1.14.2

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fxamacker/cbor/v2 v2.2.0 h1:6eXqdDDe588rSYAi1HfZKbx6YYQO4mxQ9eC6xYpU/JQ=
+github.com/fxamacker/cbor/v2 v2.2.0/go.mod h1:TA1xS00nchWmaBnEIxPSE5oHLuJBAVvqrtAnWBwBCVo=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -80,6 +82,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
+github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
+github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds a new [CBOR](https://cbor.io) (RFC-8949) codec to the codec-based marshaler implementation.

#### Why make this change?

Largely I just needed another codec for testing content negotiation. 

Rather than mocking the codec or the marshaler itself I thought it'd be easier and more useful to add another RFC-based codec that supports (just about) any data type, like JSON.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
