### PR TITLE
Add `json.DefaultCodec` and `cbor.DefaultCodec`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ The format is based on [Keep a Changelog], and this project adheres to
 [Keep a Changelog]: https://keepachangelog.com/en/1.0.0/
 [Semantic Versioning]: https://semver.org/spec/v2.0.0.html
 
+## [0.7.1] - 2021-06-09
+
+### Added
+
+- Add `json.DefaultCodec` and `cbor.DefaultCodec`
+
 ## [0.7.0] - 2021-05-05
 
 This release upgrades the protocol buffers implementation to use
@@ -112,6 +118,7 @@ different marshalers/unmarshalers provided by `google.golang.org/protobuf`.
 [0.5.0]: https://github.com/dogmatiq/marshalkit/releases/tag/v0.5.0
 [0.6.0]: https://github.com/dogmatiq/marshalkit/releases/tag/v0.6.0
 [0.7.0]: https://github.com/dogmatiq/marshalkit/releases/tag/v0.7.0
+[0.7.1]: https://github.com/dogmatiq/marshalkit/releases/tag/v0.7.1
 
 <!-- version template
 ## [0.0.1] - YYYY-MM-DD

--- a/codec/cbor/codec.go
+++ b/codec/cbor/codec.go
@@ -10,6 +10,9 @@ import (
 // Codec is an implementation of marshalkit.Codec that uses CBOR encoding.
 type Codec struct{}
 
+// DefaultCodec is a marshalkit.Codec that marshals messages using CBOR encoding.
+var DefaulCodec = Codec{}
+
 // Query returns the capabilities of the codec for the given types.
 func (*Codec) Query(types []reflect.Type) codec.Capabilities {
 	caps := codec.Capabilities{

--- a/codec/json/codec.go
+++ b/codec/json/codec.go
@@ -11,6 +11,10 @@ import (
 // implementation.
 type Codec struct{}
 
+// DefaultCodec is a marshalkit.Codec that marshals messages using Go's standard
+// JSON implementation.
+var DefaulCodec = Codec{}
+
 // Query returns the capabilities of the codec for the given types.
 func (*Codec) Query(types []reflect.Type) codec.Capabilities {
 	caps := codec.Capabilities{

--- a/codec/protobuf/codec.go
+++ b/codec/protobuf/codec.go
@@ -17,6 +17,13 @@ type Unmarshaler interface {
 	Unmarshal([]byte, proto.Message) error
 }
 
+// Codec is an implementation of marshalkit.Codec that encodes Protocol Buffers
+// messages.
+//
+// It supports three common protocol buffers formats, that is, the native binary
+// format, the JSON "mapping", and the text-based encoding scheme.
+//
+// See DefaultNativeCodec, DefaultJSONCodec and DefaultTextCodec, respectively.
 type Codec struct {
 	// MediaType is the type and subtype portion of the media-type used to
 	// identify data encoded by this codec. If it is empty, NativeMediaType is

--- a/codec/protobuf/json.go
+++ b/codec/protobuf/json.go
@@ -22,6 +22,8 @@ var DefaultJSONUnmarshaler = protojson.UnmarshalOptions{
 
 // DefaultJSONCodec is a marshalkit.Codec that marshals protocol buffers
 // messages in JSON format.
+//
+// See https://developers.google.com/protocol-buffers/docs/proto3#json.
 var DefaultJSONCodec = Codec{
 	MediaType:   JSONBasicMediaType,
 	Marshaler:   DefaultJSONMarshaler,


### PR DESCRIPTION
<!--
A complete guide to completing the pull request template is available at
https://github.com/dogmatiq/.github/CONTRIBUTING.md.

Don't forget to update the CHANGELOG.md file! :)
-->

#### What change does this introduce?

This PR adds the `json.DefaultCodec` and `cbor.DefaultCodec` variables.

#### Why make this change?

Parity with the `protobuf` package, which provides default codecs for each of its supported encoding formats.

#### Is there anything you are unsure about?

No

#### What issues does this relate to?

None
